### PR TITLE
Adjust MunkiPkginfoMerger arguments

### DIFF
--- a/TeamViewerHost/TeamViewerHost.munki.recipe
+++ b/TeamViewerHost/TeamViewerHost.munki.recipe
@@ -56,17 +56,20 @@
 			</dict>
 			<key>Processor</key>
 			<string>MunkiInstallsItemsCreator</string> 
-        </dict>
-        <dict>
-            <key>Arguments</key>
+		</dict>
+		<dict>
+			<key>Arguments</key>
 			<dict>
-                <key>version</key>
-                <string>%version%</string>
-            </dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
 			<key>Processor</key>
 			<string>MunkiPkginfoMerger</string>
 		</dict>
-        <dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>path_list</key>


### PR DESCRIPTION
`additional_pkginfo` belongs in the [MunkiPkginfoMerger](https://github.com/autopkg/autopkg/wiki/Processor-MunkiPkginfoMerger) processor.