### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/Fuze/Fuze.pkg.recipe
+++ b/Fuze/Fuze.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.flywire.pkg.Fuze</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.fuzebox.fuze.Fuze</string>
 		<key>NAME</key>
 		<string>Fuze</string>
 	</dict>

--- a/FuzeConnect/FuzeConnect.pkg.recipe
+++ b/FuzeConnect/FuzeConnect.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.flywire.pkg.Fuze-connect</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.soleng-fuze-connect-electron</string>
 		<key>NAME</key>
 		<string>FuzeConnect</string>
 	</dict>

--- a/TablePlus/TablePlus.pkg.recipe
+++ b/TablePlus/TablePlus.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.peertransfer.pkg.TablePlus</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.tinyapp.TablePlus</string>
 		<key>NAME</key>
 		<string>TablePlus</string>
 	</dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ✅ Fuze/Fuze.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/flywire-recipes/Fuze/Fuze.pkg.recipe
Processing repos/flywire-recipes/Fuze/Fuze.pkg.recipe...
URLDownloader
{'Input': {'CHECK_FILESIZE_ONLY': 'true',
           'filename': 'Fuze.dmg',
           'url': 'https://citadel.thinkingphones.com/api/v1/applications/fuzeapp/mac/versions/latest/download/installer'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.flywire.pkg.Fuze/downloads/Fuze.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.flywire.pkg.Fuze/downloads/Fuze.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.flywire.pkg.Fuze/downloads/Fuze.dmg/Fuze.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.fuzebox.fuze.Fuze" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = Z94XCC8A5K)'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.flywire.pkg.Fuze/downloads/Fuze.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.kHmGZh/Fuze.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.kHmGZh/Fuze.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.kHmGZh/Fuze.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.flywire.pkg.Fuze/downloads/Fuze.dmg/Fuze.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.flywire.pkg.Fuze/downloads/Fuze.dmg
Versioner: Found version 21.01.19354 in file /private/tmp/dmg.fsxDxm/Fuze.app/Contents/Info.plist
{'Output': {'version': '21.01.19354'}}
AppPkgCreator
{'Input': {'version': '21.01.19354'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.flywire.pkg.Fuze/downloads/Fuze.dmg
AppPkgCreator: Using path '/private/tmp/dmg.9Br2LA/Fuze.app' matched from globbed '/private/tmp/dmg.9Br2LA/*.app'.
AppPkgCreator: BundleID: com.fuzebox.fuze.Fuze
AppPkgCreator: Copied /private/tmp/dmg.9Br2LA/Fuze.app to ~/Library/AutoPkg/Cache/com.github.flywire.pkg.Fuze/payload/Applications/Fuze.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.fuzebox.fuze.Fuze',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.flywire.pkg.Fuze/Fuze-21.01.19354.pkg',
                                                        'version': '21.01.19354'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '21.01.19354'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.flywire.pkg.Fuze/receipts/Fuze.pkg-receipt-20210213-233857.plist

The following packages were built:
    Identifier             Version      Pkg Path                                                                               
    ----------             -------      --------                                                                               
    com.fuzebox.fuze.Fuze  21.01.19354  ~/Library/AutoPkg/Cache/com.github.flywire.pkg.Fuze/Fuze-21.01.19354.pkg  
```

## ✅ FuzeConnect/FuzeConnect.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/flywire-recipes/FuzeConnect/FuzeConnect.pkg.recipe
Processing repos/flywire-recipes/FuzeConnect/FuzeConnect.pkg.recipe...
URLDownloader
{'Input': {'CHECK_FILESIZE_ONLY': 'true',
           'filename': 'FuzeConnect.dmg',
           'request_headers': {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_10_3) '
                                             'AppleWebKit/537.36 (KHTML, like '
                                             'Gecko) Chrome/44.0.2403.89 '
                                             'Safari/537.36'},
           'url': 'http://fuzeconnect.gts.fuze.com/'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: File size returned by webserver matches that of the cached file: 58265175 bytes
URLDownloader: WARNING: Matching a download by filesize is a fallback mechanism that does not guarantee that a build is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.flywire.pkg.Fuze-connect/downloads/FuzeConnect.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.flywire.pkg.Fuze-connect/downloads/FuzeConnect.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.flywire.pkg.Fuze-connect/downloads/FuzeConnect.dmg/FuzeConnect.app',
           'requirement': 'identifier "com.soleng-fuze-connect-electron" and '
                          'certificate leaf = '
                          'H"791fe6a8c8499f29ec528fbf18fcf3f0385948e4"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.flywire.pkg.Fuze-connect/downloads/FuzeConnect.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.GJqF4n/FuzeConnect.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.GJqF4n/FuzeConnect.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.GJqF4n/FuzeConnect.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.flywire.pkg.Fuze-connect/downloads/FuzeConnect.dmg/FuzeConnect.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.flywire.pkg.Fuze-connect/downloads/FuzeConnect.dmg
Versioner: Found version 2.12.5 in file /private/tmp/dmg.mHMt9r/FuzeConnect.app/Contents/Info.plist
{'Output': {'version': '2.12.5'}}
AppPkgCreator
{'Input': {'version': '2.12.5'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.flywire.pkg.Fuze-connect/downloads/FuzeConnect.dmg
AppPkgCreator: Using path '/private/tmp/dmg.n3w46t/FuzeConnect.app' matched from globbed '/private/tmp/dmg.n3w46t/*.app'.
AppPkgCreator: BundleID: com.soleng-fuze-connect-electron
AppPkgCreator: Copied /private/tmp/dmg.n3w46t/FuzeConnect.app to ~/Library/AutoPkg/Cache/com.github.flywire.pkg.Fuze-connect/payload/Applications/FuzeConnect.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.soleng-fuze-connect-electron',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.flywire.pkg.Fuze-connect/FuzeConnect-2.12.5.pkg',
                                                        'version': '2.12.5'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2.12.5'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.flywire.pkg.Fuze-connect/receipts/FuzeConnect.pkg-receipt-20210213-234007.plist

The following packages were built:
    Identifier                        Version  Pkg Path                                                                                         
    ----------                        -------  --------                                                                                         
    com.soleng-fuze-connect-electron  2.12.5   ~/Library/AutoPkg/Cache/com.github.flywire.pkg.Fuze-connect/FuzeConnect-2.12.5.pkg  
```

## ✅ TablePlus/TablePlus.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/flywire-recipes/TablePlus/TablePlus.pkg.recipe
Processing repos/flywire-recipes/TablePlus/TablePlus.pkg.recipe...
URLDownloader
{'Input': {'CHECK_FILESIZE_ONLY': 'false',
           'filename': 'TablePlus.dmg',
           'request_headers': {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_10_3) '
                                             'AppleWebKit/537.36 (KHTML, like '
                                             'Gecko) Chrome/44.0.2403.89 '
                                             'Safari/537.36'},
           'url': 'https://tableplus.com/release/osx/tableplus_latest'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.peertransfer.pkg.TablePlus/downloads/TablePlus.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.peertransfer.pkg.TablePlus/downloads/TablePlus.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.peertransfer.pkg.TablePlus/downloads/TablePlus.dmg/TablePlus.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.tinyapp.TablePlus" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "3X57WP8E8V")'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.peertransfer.pkg.TablePlus/downloads/TablePlus.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.qznkM6/TablePlus.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.qznkM6/TablePlus.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.qznkM6/TablePlus.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.peertransfer.pkg.TablePlus/downloads/TablePlus.dmg/TablePlus.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.peertransfer.pkg.TablePlus/downloads/TablePlus.dmg
Versioner: Found version 3.12.4 in file /private/tmp/dmg.GlMPC9/TablePlus.app/Contents/Info.plist
{'Output': {'version': '3.12.4'}}
AppPkgCreator
{'Input': {'version': '3.12.4'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.peertransfer.pkg.TablePlus/downloads/TablePlus.dmg
AppPkgCreator: Using path '/private/tmp/dmg.vBANXk/TablePlus.app' matched from globbed '/private/tmp/dmg.vBANXk/*.app'.
AppPkgCreator: BundleID: com.tinyapp.TablePlus
AppPkgCreator: Copied /private/tmp/dmg.vBANXk/TablePlus.app to ~/Library/AutoPkg/Cache/com.github.peertransfer.pkg.TablePlus/payload/Applications/TablePlus.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.tinyapp.TablePlus',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.peertransfer.pkg.TablePlus/TablePlus-3.12.4.pkg',
                                                        'version': '3.12.4'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '3.12.4'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.peertransfer.pkg.TablePlus/receipts/TablePlus.pkg-receipt-20210213-234027.plist

The following packages were built:
    Identifier             Version  Pkg Path                                                                                         
    ----------             -------  --------                                                                                         
    com.tinyapp.TablePlus  3.12.4   ~/Library/AutoPkg/Cache/com.github.peertransfer.pkg.TablePlus/TablePlus-3.12.4.pkg  
```

