### PR TITLE
Freeze pre-commit versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
       - id: check-added-large-files
         args: ["--maxkb=100"]
@@ -18,7 +18,7 @@ repos:
       - id: trailing-whitespace
         args: ["--markdown-linebreak-ext=md"]
   - repo: https://github.com/homebysix/pre-commit-macadmin
-    rev: v1.22.0
+    rev: b580da98c4248a864b8a2190f49db5e5e02b4e93  # frozen: v1.22.0
     hooks:
       - id: check-plists
       - id: check-autopkg-recipes
@@ -27,6 +27,6 @@ repos:
       - id: forbid-autopkg-overrides
       - id: forbid-autopkg-trust-info
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.2
+    rev: 75992aaa40730136014f34227e0135f63fc951b4  # frozen: v3.21.2
     hooks:
       - id: pyupgrade


### PR DESCRIPTION
Based on [this comment](https://github.com/pre-commit-ci/issues/issues/221#issuecomment-2210820529), using the output from the --freeze flag should allow for auto updates to still work, but using the commit hash over the tag, so now you can review specific commits and not rely on version tags for increased supply chain security.